### PR TITLE
Fix four rendering issues in configurator

### DIFF
--- a/app/src/components/StepCard.jsx
+++ b/app/src/components/StepCard.jsx
@@ -77,7 +77,7 @@ export default function StepCard({ stepKey, stepData, contentData, config, spec 
           {/* Step 9 entry triggers */}
           {stepKey === 'step_9' && stepData.progression_gate && (
             <Section title="Entry Triggers">
-              <Step9EntryTriggers stepData={stepData} config={config} />
+              <Step9EntryTriggers contentData={contentData} />
             </Section>
           )}
 
@@ -129,14 +129,36 @@ export default function StepCard({ stepKey, stepData, contentData, config, spec 
                     <p className="text-xs text-slate-300">{mod.text}</p>
                   </div>
                 ))}
-                {stepContent?.configuration_notes && (
+                {stepContent?.configuration_notes && typeof stepContent.configuration_notes === 'object' && (
+                  <div className="space-y-2">
+                    {Object.entries(stepContent.configuration_notes).map(([key, text]) => {
+                      if (key.includes('DP1_no_integration') && config.dp1 !== 'no_integration') return null
+                      if (key.includes('DP1_has_integration') && config.dp1 === 'no_integration') return null
+                      if (key.includes('DP1_direction') && config.dp1 === 'no_integration') return null
+                      if (key.includes('DP2_financial_motion') && !computeHasFinancialMotion(config)) return null
+                      if (key.includes('DP2_no_financial_motion') && computeHasFinancialMotion(config)) return null
+                      if (key.includes('DP2_co_sell_direction') && !config.dp2.motions.includes('co_sell')) return null
+                      if (key.includes('DP2_co_marketing') && !config.dp2.motions.includes('co_marketing')) return null
+                      if (key.includes('DP2_marketplace') && !config.dp2.motions.some(m => m.startsWith('marketplace_'))) return null
+                      if (key.includes('DP2_referral_direction') && !(config.dp2.motions.includes('referral_inbound') && config.dp2.motions.includes('referral_outbound'))) return null
+                      if (key.includes('DP3_partner_cert') && !['partner_cert_only', 'both'].includes(config.dp3)) return null
+                      if (key.includes('DP3_integration_cert') && !['integration_cert_only', 'both'].includes(config.dp3)) return null
+                      if (key.includes('DP3_neither') && config.dp3 !== 'neither') return null
+                      if (key.includes('DP4_yes') && config.dp4 !== 'yes') return null
+                      if (key.includes('DP4_no') && config.dp4 !== 'no') return null
+                      return (
+                        <div key={key} className="bg-slate-800/50 border border-slate-700/50 rounded-lg p-3">
+                          <div className="text-xs font-medium text-slate-400 mb-1">{key.replace(/_/g, ' ')}</div>
+                          <p className="text-xs text-slate-400">{text}</p>
+                        </div>
+                      )
+                    })}
+                  </div>
+                )}
+                {stepContent?.configuration_notes && typeof stepContent.configuration_notes === 'string' && (
                   <div className="bg-slate-800/50 border border-slate-700/50 rounded-lg p-3">
                     <div className="text-xs font-medium text-slate-400 mb-1">Configuration note</div>
-                    <p className="text-xs text-slate-400">{
-                      typeof stepContent.configuration_notes === 'string'
-                        ? stepContent.configuration_notes
-                        : JSON.stringify(stepContent.configuration_notes)
-                    }</p>
+                    <p className="text-xs text-slate-400">{stepContent.configuration_notes}</p>
                   </div>
                 )}
               </div>
@@ -271,28 +293,29 @@ function evaluatePlayActive(play, config) {
   return true
 }
 
-function Step9EntryTriggers({ stepData, config }) {
-  const gate = stepData.progression_gate
-  if (!gate) return null
-
-  // Try to extract triggers from the gate description or conditions
-  const triggers = [
-    'At least one activation signal logged in Operations Record',
-    'Partner SLA compliance confirmed over trailing period',
-    'No open escalations or unresolved issues',
-    'RevOps/Finance payout mechanics confirmed (financial motions only)',
-    'Partner Manager readiness confirmed',
-  ]
+function Step9EntryTriggers({ contentData }) {
+  const triggers = contentData?.steps?.step_9?.entry_triggers
+  if (!triggers) return null
 
   return (
-    <ul className="space-y-1.5">
-      {triggers.map((t, i) => (
-        <li key={i} className="flex items-start gap-2 text-sm text-slate-400">
-          <span className="text-cyan-600 mt-0.5 text-xs">✓</span>
-          <span>{t}</span>
-        </li>
-      ))}
-    </ul>
+    <div className="space-y-3">
+      {triggers.description && (
+        <p className="text-sm text-slate-400 italic">{triggers.description}</p>
+      )}
+      {triggers.gates && (
+        <ul className="space-y-1.5">
+          {triggers.gates.map((gate, i) => (
+            <li key={i} className="flex items-start gap-2 text-sm text-slate-400">
+              <span className="text-cyan-600 mt-0.5 text-xs">✓</span>
+              <span>{gate}</span>
+            </li>
+          ))}
+        </ul>
+      )}
+      {triggers.governance_note && (
+        <p className="text-xs text-slate-500 mt-2">{triggers.governance_note}</p>
+      )}
+    </div>
   )
 }
 
@@ -422,8 +445,8 @@ function FullDetailLayer({ stepContent, stepData, config }) {
           <div className="space-y-2">
             {stepContent.tie_breaker_escalation.map((item, i) => {
               const isInactive = item.configuration_dependent && (
-                (item.active_when === 'dp4_yes' && config.dp4 !== 'yes') ||
-                (item.active_when === 'dp4_no' && config.dp4 === 'yes')
+                (item.active_when && item.active_when.includes("'yes'") && config.dp4 !== 'yes') ||
+                (item.active_when && item.active_when.includes("'no'") && config.dp4 !== 'no')
               )
               return (
                 <div key={i} className={`flex gap-3 ${isInactive ? 'opacity-40' : ''}`}>

--- a/app/src/engine.js
+++ b/app/src/engine.js
@@ -67,39 +67,71 @@ export function getActiveWorkflowModifications(stepKey, stepData, spec, config) 
     const ruleSet = rules[ruleKey]
     if (!ruleSet) continue
 
-    // Find matching variant
-    let matched = null
+    // Collect ALL matching variants independently (not else-if)
+    const variants = []
+
+    // DP1 variants
     if (config.dp1 === 'entity_to_partner' && ruleSet.when_DP1_is_entity_to_partner)
-      matched = { label: 'Integration direction (entity → partner)', text: ruleSet.when_DP1_is_entity_to_partner }
-    else if (config.dp1 === 'partner_to_entity' && ruleSet.when_DP1_is_partner_to_entity)
-      matched = { label: 'Integration direction (partner → entity)', text: ruleSet.when_DP1_is_partner_to_entity }
-    else if (config.dp1 === 'bidirectional' && ruleSet.when_DP1_is_bidirectional)
-      matched = { label: 'Integration direction (bidirectional)', text: ruleSet.when_DP1_is_bidirectional }
-    else if (config.dp1 === 'no_integration' && ruleSet.when_DP1_is_no_integration)
-      matched = { label: 'No technical integration', text: ruleSet.when_DP1_is_no_integration }
-    else if (config.dp4 === 'yes' && ruleSet.when_DP4_is_yes)
-      matched = { label: 'Regulated industries active', text: ruleSet.when_DP4_is_yes }
-    else if (config.dp4 === 'no' && ruleSet.when_DP4_is_no)
-      matched = { label: 'No regulated industries', text: ruleSet.when_DP4_is_no }
-    else if (config.dp2.motions.includes('reseller_partner') && ruleSet.when_reseller_partner_selected)
-      matched = { label: 'Reseller (partner) motion', text: ruleSet.when_reseller_partner_selected }
-    else if (config.dp2.motions.includes('reseller_entity') && ruleSet.when_reseller_entity_selected)
-      matched = { label: 'Reseller (entity) motion', text: ruleSet.when_reseller_entity_selected }
-    else if (config.dp2.motions.includes('marketplace_third_party') && ruleSet.when_marketplace_third_party_selected)
-      matched = { label: 'Third-party marketplace', text: ruleSet.when_marketplace_third_party_selected }
-    else if (computeHasFinancialMotion(config) || config.dp2.motions.includes('co_sell')) {
-      if (ruleSet.when_co_sell_is_entity_led && config.dp2.co_sell_direction === 'entity_led')
-        matched = { label: 'Co-sell: entity-led', text: ruleSet.when_co_sell_is_entity_led }
-      else if (ruleSet.when_co_sell_is_partner_led && config.dp2.co_sell_direction === 'partner_led')
-        matched = { label: 'Co-sell: partner-led', text: ruleSet.when_co_sell_is_partner_led }
-      else if (ruleSet.when_co_sell_is_jointly_led && config.dp2.co_sell_direction === 'jointly_led')
-        matched = { label: 'Co-sell: jointly-led', text: ruleSet.when_co_sell_is_jointly_led }
+      variants.push({ label: 'Integration direction (entity → partner)', text: ruleSet.when_DP1_is_entity_to_partner })
+    if (config.dp1 === 'partner_to_entity' && ruleSet.when_DP1_is_partner_to_entity)
+      variants.push({ label: 'Integration direction (partner → entity)', text: ruleSet.when_DP1_is_partner_to_entity })
+    if (config.dp1 === 'bidirectional' && ruleSet.when_DP1_is_bidirectional)
+      variants.push({ label: 'Integration direction (bidirectional)', text: ruleSet.when_DP1_is_bidirectional })
+    if (config.dp1 === 'no_integration' && ruleSet.when_DP1_is_no_integration)
+      variants.push({ label: 'No technical integration', text: ruleSet.when_DP1_is_no_integration })
+
+    // DP4 variants
+    if (config.dp4 === 'yes' && ruleSet.when_DP4_is_yes)
+      variants.push({ label: 'Regulated industries active', text: ruleSet.when_DP4_is_yes })
+    if (config.dp4 === 'no' && ruleSet.when_DP4_is_no)
+      variants.push({ label: 'No regulated industries', text: ruleSet.when_DP4_is_no })
+
+    // DP2 motion variants
+    if (config.dp2.motions.includes('reseller_partner') && ruleSet.when_reseller_partner_selected)
+      variants.push({ label: 'Reseller (partner) motion', text: ruleSet.when_reseller_partner_selected })
+    if (config.dp2.motions.includes('reseller_entity') && ruleSet.when_reseller_entity_selected)
+      variants.push({ label: 'Reseller (entity) motion', text: ruleSet.when_reseller_entity_selected })
+    if (config.dp2.motions.includes('marketplace_third_party') && ruleSet.when_marketplace_third_party_selected)
+      variants.push({ label: 'Third-party marketplace', text: ruleSet.when_marketplace_third_party_selected })
+    if (config.dp2.motions.includes('referral_inbound') && ruleSet.when_referral_inbound_selected)
+      variants.push({ label: 'Referral (inbound) motion', text: ruleSet.when_referral_inbound_selected })
+    if (config.dp2.motions.includes('referral_outbound') && ruleSet.when_referral_outbound_selected)
+      variants.push({ label: 'Referral (outbound) motion', text: ruleSet.when_referral_outbound_selected })
+    if (config.dp2.motions.includes('marketplace_entity') && ruleSet.when_marketplace_entity_selected)
+      variants.push({ label: 'Marketplace (entity) motion', text: ruleSet.when_marketplace_entity_selected })
+    if (config.dp2.motions.includes('co_sell') && ruleSet.when_co_sell_selected)
+      variants.push({ label: 'Co-sell motion', text: ruleSet.when_co_sell_selected })
+    if (config.dp2.motions.includes('co_marketing') && ruleSet.when_co_marketing_selected)
+      variants.push({ label: 'Co-marketing motion', text: ruleSet.when_co_marketing_selected })
+
+    // Financial motion variants
+    if (computeHasFinancialMotion(config) && ruleSet.when_financial_motion_selected)
+      variants.push({ label: 'Financial motion active', text: ruleSet.when_financial_motion_selected })
+    if (!computeHasFinancialMotion(config) && ruleSet.when_no_financial_motion)
+      variants.push({ label: 'No financial motion', text: ruleSet.when_no_financial_motion })
+
+    // Co-sell direction variants
+    if (config.dp2.motions.includes('co_sell')) {
+      if (config.dp2.co_sell_direction === 'entity_led' && ruleSet.when_direction_is_entity_led)
+        variants.push({ label: 'Co-sell: entity-led', text: ruleSet.when_direction_is_entity_led })
+      if (config.dp2.co_sell_direction === 'partner_led' && ruleSet.when_direction_is_partner_led)
+        variants.push({ label: 'Co-sell: partner-led', text: ruleSet.when_direction_is_partner_led })
+      if (config.dp2.co_sell_direction === 'jointly_led' && ruleSet.when_direction_is_jointly_led)
+        variants.push({ label: 'Co-sell: jointly-led', text: ruleSet.when_direction_is_jointly_led })
+      // Also check old key names used in some rules
+      if (config.dp2.co_sell_direction === 'entity_led' && ruleSet.when_co_sell_is_entity_led)
+        variants.push({ label: 'Co-sell: entity-led', text: ruleSet.when_co_sell_is_entity_led })
+      if (config.dp2.co_sell_direction === 'partner_led' && ruleSet.when_co_sell_is_partner_led)
+        variants.push({ label: 'Co-sell: partner-led', text: ruleSet.when_co_sell_is_partner_led })
+      if (config.dp2.co_sell_direction === 'jointly_led' && ruleSet.when_co_sell_is_jointly_led)
+        variants.push({ label: 'Co-sell: jointly-led', text: ruleSet.when_co_sell_is_jointly_led })
     }
 
-    if (!matched && ruleSet.when_no_referral_or_reseller_motion && !computeHasFinancialMotion(config))
-      matched = { label: 'No commercial motion', text: ruleSet.when_no_referral_or_reseller_motion }
+    // Fallback: no commercial motion
+    if (variants.length === 0 && ruleSet.when_no_referral_or_reseller_motion && !computeHasFinancialMotion(config))
+      variants.push({ label: 'No commercial motion', text: ruleSet.when_no_referral_or_reseller_motion })
 
-    if (matched) result.push(matched)
+    result.push(...variants)
   }
 
   return result


### PR DESCRIPTION
Fix 1 (Step9EntryTriggers): Read entry_triggers from supplementary_content.json instead of hardcoded list — renders description, gates array, and governance_note.

Fix 2 (configuration_notes): Parse object structure and filter keys by current config instead of JSON.stringify dumping raw data to screen.

Fix 3 (tie-breaker active_when): Use .includes() to match against actual JSON string format ("DP4 == 'yes'") instead of literal 'dp4_yes' comparison.

Fix 4 (workflow modifications): Collect all matching variants per rule with independent if-checks instead of if/else-if chain — surfaces multiple simultaneous modifications (e.g. DP2 reseller + DP4 compliance on Step 4).

https://claude.ai/code/session_018dekHRYT5RzMWmLnocghWV